### PR TITLE
Fix random playback caching

### DIFF
--- a/ui/tkinter_ui.py
+++ b/ui/tkinter_ui.py
@@ -302,6 +302,8 @@ class PlayerApp:
         elif mode == "循环":
             return (self.current_index + 1) % len(self.music_files)
         elif mode == "随机":
+            if self.next_audio_data:
+                return self.next_audio_data[0]
             candidates = list(range(len(self.music_files)))
             if len(candidates) > 1:
                 candidates.remove(self.current_index)


### PR DESCRIPTION
## Summary
- reuse cached next index when in random mode

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d40bd26cc8333a426314110e62243