### PR TITLE
Add persistent user settings

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,0 +1,26 @@
+import json
+import os
+
+SETTINGS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'user_settings.json')
+
+DEFAULT_SETTINGS = {
+    "device": "cuda",
+    "play_mode": "顺序"
+}
+
+def load_settings():
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            return {**DEFAULT_SETTINGS, **data}
+        except Exception:
+            return DEFAULT_SETTINGS.copy()
+    return DEFAULT_SETTINGS.copy()
+
+def save_settings(settings):
+    try:
+        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(settings, f, ensure_ascii=False, indent=2)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- implement loading/saving of device and play mode options
- integrate settings persistence into Tkinter player

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d42a076c883339bcbcc22c610b98f