### PR TITLE
Add packaging script and update requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Music Player with Vocal Separation
+
+This project is a simple GUI music player that separates vocals from a track using Demucs and plays the result with a Tkinter interface.
+
+## Installation
+
+1. Create a Python environment.
+2. Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the application directly from the repository:
+
+```bash
+python main.py
+```
+
+## Packaging
+
+To create a standalone executable you can use [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile --add-data "user_settings.json:." main.py
+```
+
+The generated binary will be in the `dist/` directory. The `--add-data` option ensures `user_settings.json` is bundled so user preferences are stored next to the executable.

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Build a standalone executable with PyInstaller
+pip install pyinstaller
+pyinstaller --onefile --add-data "user_settings.json:." main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-spleeter
-pydub
-pygame
+torch
+torchaudio
+demucs
+sounddevice
 librosa
+soundfile

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,7 +1,9 @@
 import json
 import os
+import sys
 
-SETTINGS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'user_settings.json')
+BASE_DIR = getattr(sys, '_MEIPASS', os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+SETTINGS_FILE = os.path.join(BASE_DIR, 'user_settings.json')
 
 DEFAULT_SETTINGS = {
     "device": "cuda",


### PR DESCRIPTION
## Summary
- add instructions to README on running and packaging with PyInstaller
- update requirements.txt with actual dependencies
- adjust settings path to support PyInstaller
- provide `package.sh` helper script
- add `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d4d271768833393eb5f3aa5024b37