### PR TITLE
Improve playlist UI and lyrics display

### DIFF
--- a/lyrics/lyrics_display.py
+++ b/lyrics/lyrics_display.py
@@ -3,37 +3,56 @@ import time
 import threading
 
 def start_lyrics_display(lyrics, player, text_widget=None):
+    manual_scroll_time = 0
+
+    def on_scroll(event=None):
+        nonlocal manual_scroll_time
+        manual_scroll_time = time.time()
+
+    def center_line(line_number):
+        if not text_widget:
+            return
+        text_widget.see(f"{line_number}.0")
+        text_widget.update_idletasks()
+        total = int(text_widget.index("end-1c").split(".")[0])
+        visible = int(text_widget['height'])
+        first = max(min(line_number - visible // 2, total - visible), 0)
+        fraction = first / max(total - visible, 1)
+        text_widget.yview_moveto(fraction)
+
     def display():
         last_index = -1
         while player and (player.playing or player.paused):
             current_time = player.get_current_time()
 
-            # 定位当前歌词行索引
             idx = 0
             while idx + 1 < len(lyrics) and current_time >= lyrics[idx + 1][0]:
                 idx += 1
 
             if idx != last_index and text_widget:
-                # 清除旧高亮
                 text_widget.tag_remove("current", "1.0", "end")
-
-                # 精确高亮第 idx 行（从 1.0 开始）
                 line_number = idx + 1
                 start = f"{line_number}.0"
                 end = f"{line_number}.end"
-
                 text_widget.tag_add("current", start, end)
-                text_widget.tag_config("current", foreground="red", font=("Microsoft YaHei", 14, "bold"))
-                text_widget.see(start)
-
+                text_widget.tag_config(
+                    "current", foreground="red",
+                    font=("Microsoft YaHei", 14, "bold"))
+                if time.time() - manual_scroll_time > 30:
+                    center_line(line_number)
                 last_index = idx
 
             time.sleep(0.1)
 
-    # 初始化：显示所有歌词
     if text_widget:
         text_widget.delete("1.0", "end")
+        text_widget.tag_config("center", justify="center")
         for _, line in lyrics:
             text_widget.insert("end", line + "\n")
+        text_widget.tag_add("center", "1.0", "end")
+        text_widget.bind("<MouseWheel>", on_scroll)
+        text_widget.bind("<Button-4>", on_scroll)
+        text_widget.bind("<Button-5>", on_scroll)
+        text_widget.bind("<ButtonPress-1>", on_scroll)
 
     threading.Thread(target=display, daemon=True).start()


### PR DESCRIPTION
## Summary
- rename add-to-queue button text
- add collapsible playlist with per-item delete and clear buttons
- keep highlighted lyrics centered and enable temporary manual scrolling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68533c7155308333853d1e87064bd520